### PR TITLE
Changed lms.properties path in ConnectionUtil class because the

### DIFF
--- a/src/main/java/com/ss/training/spring/lms/service/ConnectionUtil.java
+++ b/src/main/java/com/ss/training/spring/lms/service/ConnectionUtil.java
@@ -19,7 +19,7 @@ public class ConnectionUtil {
 	public Connection getConnection() {
 		Connection conn = null;
 		Properties prop = new Properties();
-		try (InputStream input = new FileInputStream("resources/config/lms.properties")) {
+		try (InputStream input = new FileInputStream("src/main/resources/lms.properties")) {
 			prop.load(input);
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/src/main/java/com/ss/training/spring/lms/service/SpringConfig.java
+++ b/src/main/java/com/ss/training/spring/lms/service/SpringConfig.java
@@ -1,0 +1,31 @@
+package com.ss.training.spring.lms.service;
+
+import java.sql.Connection;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.ss.training.spring.lms.dao.AuthorDAO;
+
+/**
+ * Spring configuration class that sets up beans used in the application
+ * 
+ * @author jalveste
+ *
+ */
+@Configuration
+public class SpringConfig {
+	public ConnectionUtil connUtil = new ConnectionUtil();
+
+	@Bean
+	public AdminService authorServiceBean() {
+		return new AdminService();
+	}
+
+	@Bean
+	public AuthorDAO authorDAOBean() {
+		Connection conn = null;
+		conn = connUtil.getConnection();
+		return new AuthorDAO(conn);
+	}
+}


### PR DESCRIPTION
Changed lms.properties path in ConnectionUtil class because the directory structure is different in this project.  Add your lms.properties file in the src/main/resources folder, next to
application.properties file.

I also added the SpringConfig class exactly as demonstrated in class.
This sets up the beans.  It will also pass the connection object to the
DAO classes.  You can add your Service classes and DAOs here as well.  You can comment out the AdminService class bean for the time being and add your own service class instead.

Remember to add the @Autowired annotation to your DAO variables in your Service class.  It should work with this setup.

I got an author read working properly with these classes.